### PR TITLE
fix speedup measure

### DIFF
--- a/src/forbenchmark_default.f90
+++ b/src/forbenchmark_default.f90
@@ -279,7 +279,7 @@ contains
 
       if (this%marks(this%imark)%elapsed_time <= epsilon(0.0_rk)) error stop 'Elapsed time is too small'
 
-      this%marks(this%imark)%speedup = this%marks(this%imark)%elapsed_time/this%marks(1)%elapsed_time
+      this%marks(this%imark)%speedup = this%marks(1)%elapsed_time/this%marks(this%imark)%elapsed_time
 
       if (present(flops)) then
          print'(a,f7.3,a)', ' Speedup      :', this%marks(this%imark)%speedup,' [-]'


### PR DESCRIPTION
invert ratio for measuring speedup, the first benchmark being the reference shall be in the numerator.